### PR TITLE
Fixing the hash output

### DIFF
--- a/HashingHelper/MainForm.cs
+++ b/HashingHelper/MainForm.cs
@@ -1,5 +1,6 @@
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
+using System.Text;
 
 namespace HashingHelper
 {
@@ -66,8 +67,8 @@ namespace HashingHelper
                                                        FileShare.ReadWrite))
                 {
                     var hash = cryptoService.ComputeHash(fileStream);
-                    var hashString = Convert.ToBase64String(hash);
-                    return hashString.TrimEnd('=');
+                    var hashString = BitConverter.ToString(hash);
+                    return hashString.Replace("-", string.Empty);
                 }
             }
         }


### PR DESCRIPTION
Had to mess with the encoding of the bytes after the calculation.  I got to looking at the output and realized something wasn't right.  I hashed the same files in another program and sure enough totally different values.  The issue was in converting the byte array into a string.  Tried a couple different ways and got it working properly now. 